### PR TITLE
Add CentOS as a supported operating system.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,6 +8,7 @@ provisioner:
   name: chef_solo
 
 platforms:
+  - name: centos-6.5
   - name: ubuntu-12.04
 
 suites:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A cookbook to manage an installation of [Elixir](http://elixir-lang.org/).
 
 ## Supported Platforms
 
+* CentOS
 * Ubuntu
 
 ## Attributes

--- a/recipes/_package.rb
+++ b/recipes/_package.rb
@@ -5,7 +5,13 @@
 # Copyright (C) 2013-2014 Jamie Winsor (<jamie@vialstudios.com>)
 #
 
-node.normal[:erlang][:esl][:version] = "1:17.3"
+case node['platform_family']
+  when 'debian'
+    node.normal[:erlang][:esl][:version] = "1:17.3"
+  when 'rhel'
+    node.normal[:erlang][:esl][:version] = "17.3-1.el6"
+end
+
 elixir_path = File.join(node[:elixir][:_versions_path], node[:elixir][:version])
 
 include_recipe "apt::default"


### PR DESCRIPTION
The CentOS esl package used the format x.x-x.elx. I added a platform_family method to distinguish between debian and rhel based systems. 
