### PR TITLE
fix: repair workflow secrets and permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,3 +21,5 @@ jobs:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}
       supermarket_key: ${{ secrets.CHEF_SUPERMARKET_KEY }}
+      slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+      slack_channel_id: ${{ secrets.SLACK_CHANNEL_ID }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,9 @@ name: Mark stale issues and pull requests
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v10
         with:


### PR DESCRIPTION
## Summary
- pass the required Slack secrets into the reusable release workflow
- add explicit issue and pull request write permissions for the stale workflow
- review the other reusable workflow call sites in this repo; no other missing required secrets were found locally

## Verification
- parsed the edited workflow YAML with Ruby
- actionlint is not installed in this checkout